### PR TITLE
Fix: bind Strapi server to Render dynamic port

### DIFF
--- a/config/server.js
+++ b/config/server.js
@@ -1,7 +1,7 @@
 module.exports = ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
+  host: '0.0.0.0',
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS', ['toBeReplaced', 'withProperValues']),
+    keys: env.array('APP_KEYS', ['defaultKey1', 'defaultKey2']),
   },
 });


### PR DESCRIPTION
## Summary
- configure Strapi to bind to 0.0.0.0 with Render's dynamic port
- define default app keys for the Strapi server configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e598115d7c832680838721c48f80b9