### PR TITLE
Fix: force Strapi to bind to Render port using RENDER_EXTERNAL_URL

### DIFF
--- a/config/server.js
+++ b/config/server.js
@@ -1,7 +1,8 @@
 module.exports = ({ env }) => ({
-  host: '0.0.0.0',
-  port: env.int('PORT', 1337),
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', process.env.PORT || 1337),
+  url: env('RENDER_EXTERNAL_URL', `http://0.0.0.0:${process.env.PORT || 1337}`),
   app: {
-    keys: env.array('APP_KEYS', ['defaultKey1', 'defaultKey2']),
+    keys: env.array('APP_KEYS', ['key1', 'key2']),
   },
 });


### PR DESCRIPTION
## Summary
- configure Strapi server to bind to Render's provided host and port and expose the Render external URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59aad29248326815dc97bfdcfc211