### PR TITLE
Fix: move public folder into src for Strapi compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules/
 .build
 .cache
 .tmp
-public/uploads
+src/public/uploads
 package-lock.json
 yarn.lock


### PR DESCRIPTION
## Summary
- update the ignore rule for Strapi uploads to point at `src/public`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6fbbeee4c8326863da6823101f1b3